### PR TITLE
Add a domain sorting function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ version = "0.1.0"
 repository = "https://github.com/jonasbb/python-snippets"
 readme = "README.md"
 
+[tool.poetry.scripts]
+domainsort = "python_snippets.scripts:domainsort"
+
 [tool.poetry.dependencies]
 # Sync with CI
 python = "^3.10"

--- a/python_snippets/domains.py
+++ b/python_snippets/domains.py
@@ -1,0 +1,51 @@
+def domain_sort_key(domain: str) -> tuple[list[str], bool]:
+    """
+    Create a sort key for a list of domains
+
+    This function converts the `domain` into a sortable key.
+    The keys sort using the "Canonical DNS Name Order" as defined in [RFC 4034](https://datatracker.ietf.org/doc/html/rfc4034#section-6.1).
+
+    # Example
+
+    ```python
+    domains = ['z.example', 'Z.a.example', '*.z.example', 'example', 'a.example']
+    domains.sort(key=python_snippets.domains.domain_sort_key)
+    assert domains == ['example', 'a.example', 'Z.a.example', 'z.example', '*.z.example']
+    ```
+    """
+
+    labels: list[str] = []
+    is_escaped = False
+    curr_label: list[str] = []
+
+    # Domain sorting happens case insensitive
+    domain = domain.lower()
+
+    # Process labels char by char
+    # Handling escaped internal dots, i.e.,
+    # www.exa\.mple.net -> ["www", "exa.mple", "net"]
+    for c in domain:
+        if is_escaped:
+            if c == ".":
+                curr_label += c
+                is_escaped = False
+            else:
+                raise ValueError("In domains only the `.` character can be escaped.")
+        else:
+            if c == "\\":
+                is_escaped = True
+            elif c == ".":
+                labels.append("".join(curr_label))
+                curr_label = []
+            else:
+                curr_label.append(c)
+
+    # Add last label to the list of labels
+    if len(curr_label) > 0:
+        labels.append("".join(curr_label))
+    is_fqdn = len(curr_label) == 0
+
+    # Reverse labels to sort by TLD, SLD, etc
+    labels.reverse()
+
+    return (labels, is_fqdn)

--- a/python_snippets/scripts/__init__.py
+++ b/python_snippets/scripts/__init__.py
@@ -1,0 +1,13 @@
+import fileinput
+
+from ..domains import domain_sort_key
+
+
+def domainsort() -> None:
+    """Read a list of domains from stdin or from file and sort them."""
+
+    for x in sorted(
+        fileinput.input(encoding="utf-8"),
+        key=lambda x: domain_sort_key(x.strip()),
+    ):
+        print(x, end="")

--- a/tests/domainsort_test.py
+++ b/tests/domainsort_test.py
@@ -1,0 +1,28 @@
+import random
+
+from python_snippets.domains import domain_sort_key
+
+
+def test_domainsort() -> None:
+    # https://datatracker.ietf.org/doc/html/rfc4034#section-6.1
+    solution = [
+        "example",
+        "a.example",
+        "a.example.",  # Not in RFC, sort FQDN after
+        "yljkjljk.a.example",
+        "Z.a.example",
+        "Z.a.example.",  # Not in RFC, sort FQDN after
+        "zABC.a.EXAMPLE",
+        "z.example",
+        "\001.z.example",
+        "*.z.example",
+        "\200.z.example",
+    ]
+
+    # Copy domains list
+    domains = solution[:]
+    for _ in range(100):
+        # Shuffle in place
+        random.shuffle(domains)
+        domains.sort(key=domain_sort_key)
+        assert solution == domains, "Sorting resulted in a wrong domain order"


### PR DESCRIPTION
Sorts domains according to the canonical domain order (RFC 4034).
Add a command line program that installs and sorts all its input as if
they are lists of domains.